### PR TITLE
fix: revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,35 +68,15 @@ body {
 header {
     padding: 1.5rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {


### PR DESCRIPTION
This PR addresses issue #3 by reverting the header to its older version while preserving the theme toggle functionality.

## Changes
- Removed "Course Materials Assistant" header title
- Removed subheader text about asking questions
- Removed horizontal border below header
- Preserved theme toggle button in top-right position

Generated with [Claude Code](https://claude.ai/code)